### PR TITLE
Devops/secure release OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,4 +37,6 @@ jobs:
         run: npm run webpack
 
       - name: Publish Types to NPM
-        run: npm publish --access public
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,5 +38,3 @@ jobs:
 
       - name: Publish Types to NPM
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
+
 jobs:
   release:
     name: Release and Publish
@@ -34,7 +38,3 @@ jobs:
 
       - name: Publish Types to NPM
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
-# Made with Bob


### PR DESCRIPTION
Branch Summary: devops/secureReleaseOIDC
This branch implements secure NPM publishing using OIDC authentication and updates dependencies. It contains 5 commits ahead of main:

Key Changes:
1. Security Enhancement - OIDC Authentication

Added OIDC permissions (id-token: write, contents: read) to the workflow
Switched from token-based authentication to provenance-based publishing
Removed NODE_AUTH_TOKEN environment variable (final commit removes it after earlier commits added provenance support)
Added --provenance flag to npm publish command


Critical Issue:
The final commit (45c63de) removes NODE_AUTH_TOKEN, which may cause NPM authentication to fail unless OIDC-based npm provenance is fully configured for this repository. The --provenance flag alone does not replace authentication - it only adds attestation metadata. NPM publishing still requires authentication via either NODE_AUTH_TOKEN or properly configured OIDC trusted publishing.